### PR TITLE
[rtc] Allow writing to and waking up from  RTC

### DIFF
--- a/arch/arm/boot/dts/msm-pm8941.dtsi
+++ b/arch/arm/boot/dts/msm-pm8941.dtsi
@@ -532,8 +532,8 @@
 			compatible = "qcom,qpnp-rtc";
 			#address-cells = <1>;
 			#size-cells = <1>;
-			qcom,qpnp-rtc-write = <0>;
-			qcom,qpnp-rtc-alarm-pwrup = <0>;
+			qcom,qpnp-rtc-write = <1>;
+			qcom,qpnp-rtc-alarm-pwrup = <1>;
 
 			qcom,pm8941_rtc_rw@6000 {
 				reg = <0x6000 0x100>;


### PR DESCRIPTION
Adjust the devicetree entries for the RTC to allow for
setting it and have the device wake up from it.

Signed-off-by: Philippe De Swert philippe.deswert@jollamobile.com
